### PR TITLE
Update pom.xml

### DIFF
--- a/jemma.osgi.utils/pom.xml
+++ b/jemma.osgi.utils/pom.xml
@@ -49,6 +49,8 @@
 							 javax.xml.bind.annotation.adapters,
 							 javax.xml.bind.helpers,
 							 javax.xml.namespace,
+							 javax.crypto,
+							 javax.crypto.spec,
 							 org.apache.commons.codec,
 							 org.apache.commons.logging,
 							 org.eclipse.osgi.framework.console;version="1.0.0",


### PR DESCRIPTION
Modified Import-Package, added missing reference to javax.crypto.
Required when launching Jemma with Apache Felix.
