### PR TITLE
Updated pom.xml, fixes jar generation

### DIFF
--- a/jemma.osgi.ah.felix.console.web/pom.xml
+++ b/jemma.osgi.ah.felix.console.web/pom.xml
@@ -56,7 +56,7 @@
 						</Import-Package>
 						<Export-Package>!*</Export-Package>
 						<Bundle-ActivationPolicy>lazy</Bundle-ActivationPolicy>
-						<Private-Package>org.energy_home.jemma.osgi.ah.felix.console.web</Private-Package>
+						<Private-Package>org.energy_home.jemma.ah.felix.console.web</Private-Package>
 						<Service-Component>OSGI-INF/HacWebCommandProvider.xml</Service-Component>
 						<Bundle-Vendor>Telecom Italia</Bundle-Vendor>
 						<Bundle-Category>Automation@Home</Bundle-Category>


### PR DESCRIPTION
Without this, the generated jar does not contain any .class.
Weird behaviour of the bundle plugin? Shouldn't the jar contain all the classes even with this wrong field?
