### PR TITLE
added a few lines to specify how to set user/pass for javagal GUI

### DIFF
--- a/jemma.osgi.javagal.gui/README.md
+++ b/jemma.osgi.javagal.gui/README.md
@@ -7,6 +7,18 @@ To change the root context (the path) of the GUI application, you need to change
 
 An example:
 
-	<property name="rootContext" type="String" value="Zigbee"/>
+	<property name="rootContext" type="String" value="zigbee"/>
 
-In this case the web application will be available at the address http://address:port/Zigbee
+In this case the web application will be available at the address http://address:port/zigbee
+
+##Setting administrative user/pass for java GAL administrative GUI
+
+In order to get a local login/pass for the javaGAL GUI, you should add properties, e.g. in your launch configuration, as in the following example:
+
+``````
+-Dorg.energy_home.jemma.username=javagaladmin
+-Dorg.energy_home.jemma.password=javagaladmin
+``````
+
+
+


### PR DESCRIPTION
Added 2 notes to README.

We may also want to review [GalGuiHttpApplication.java](https://github.com/ismb/jemma/blob/master/jemma.osgi.javagal.gui/src/main/java/org/energy_home/jemma/javagal/gui/GalGuiHttpApplication.java) to check how users are authorized. We correctly use the OSGi UserAdmin service, but the current implementation is not really 100% readable ...